### PR TITLE
Install tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,16 @@ ENV OUTPUT_FOLDER /mnt/output
 ENV MISMATCHES 1
 ENV CPU_NUM 4
 
+# install tini - a tiny init process (PID 1) for containers
+# https://github.com/krallin/tini
+# Although this is equivalent to passing the --init flag to 'docker run' command in Docker 1.13
+# and higher, installing tini is still needed if user is using old Docker versions. This can also
+# enforce containers running with a init process regardless of using the --init flag.
+RUN curl -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v0.16.1/tini \
+ && chmod +x /usr/local/bin/tini
+
+ENTRYPOINT ["/usr/local/bin/tini", "--"]
+
 CMD /usr/local/bin/configureBclToFastq.pl \
     --input-dir $RUN_FOLDER/Data/Intensities/BaseCalls/ \
     --output-dir $OUTPUT_FOLDER/Unaligned \


### PR DESCRIPTION
Although this is equivalent to passing the `--init` flag to `docker run` command in Docker 1.13 and higher, installing `tini` is still needed if user is using old Docker versions. This can also enforce containers running with a init process regardless of using the `--init` flag.