### PR TITLE
Create a new Docker image for Bcl2fastq v2.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
-# bcl2fastq has been primarily developed and tested on CentOS 5, Illumina's
-# recommended and supported platform. However, CentOS 5 reached end-of-life
-# on March 31, 2017. To ensure the maximum compatibility, this image uses 7.
 FROM centos:7
 
 MAINTAINER Mingda Jin
 
-RUN curl -OsSL ftp://webdata:webdata@ussd-ftp.illumina.com/Downloads/Software/bcl2fastq/bcl2fastq-1.8.4-Linux-x86_64.rpm \
- && yum -y --nogpgcheck install bcl2fastq-1.8.4-Linux-x86_64.rpm \
- && yum clean all \
- && rm -f bcl2fastq-1.8.4-Linux-x86_64.rpm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        unzip \
+ && rm -rf /var/lib/apt/lists/*
 
-ENV RUN_FOLDER /mnt/run
-ENV OUTPUT_FOLDER /mnt/output
-ENV MISMATCHES 1
-ENV CPU_NUM 4
+RUN curl -OsSL ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/software/bcl2fastq/bcl2fastq2-v2.17.1.14-Linux-x86_64.zip \
+ && unzip bcl2fastq2-v2.17.1.14-Linux-x86_64.zip \
+ && yum -y --nogpgcheck install bcl2fastq2-v2.17.1.14-Linux-x86_64.rpm \
+ && yum clean all \
+ && rm -f bcl2fastq2-v2.17.1.14-Linux-x86_64.rpm \
+ && rm -f bcl2fastq2-v2.17.1.14-Linux-x86_64.zip
+
+#ENV RUN_FOLDER /mnt/run
+#ENV OUTPUT_FOLDER /mnt/output
+#ENV MISMATCHES 1
+#ENV CPU_NUM 4
 
 # install tini - a tiny init process (PID 1) for containers
 # https://github.com/krallin/tini
@@ -23,14 +26,14 @@ ENV CPU_NUM 4
 RUN curl -o /usr/local/bin/tini -sSL https://github.com/krallin/tini/releases/download/v0.16.1/tini \
  && chmod +x /usr/local/bin/tini
 
-ENTRYPOINT ["/usr/local/bin/tini", "--"]
+#ENTRYPOINT ["/usr/local/bin/tini", "--"]
 
-CMD /usr/local/bin/configureBclToFastq.pl \
-    --input-dir $RUN_FOLDER/Data/Intensities/BaseCalls/ \
-    --output-dir $OUTPUT_FOLDER/Unaligned \
-    --fastq-cluster-count 0 \
-    --mismatches $MISMATCHES \
-    --no-eamss \
-    --with-failed-reads \
- && make -j $CPU_NUM -C $OUTPUT_FOLDER/Unaligned/
+#CMD /usr/local/bin/configureBclToFastq.pl \
+    #--input-dir $RUN_FOLDER/Data/Intensities/BaseCalls/ \
+    #--output-dir $OUTPUT_FOLDER/Unaligned \
+    #--fastq-cluster-count 0 \
+    #--mismatches $MISMATCHES \
+    #--no-eamss \
+    #--with-failed-reads \
+ #&& make -j $CPU_NUM -C $OUTPUT_FOLDER/Unaligned/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -OsSL ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/software/
 ENV RUN_FOLDER /mnt/run
 ENV OUTPUT_FOLDER /mnt/output
 ENV MISMATCHES 1
-ENV CPU_NUM 4
+#ENV CPU_NUM 4
 
 # install tini - a tiny init process (PID 1) for containers
 # https://github.com/krallin/tini
@@ -27,14 +27,12 @@ ENV CPU_NUM 4
 RUN curl -o /usr/local/bin/tini -sSL https://github.com/krallin/tini/releases/download/v0.16.1/tini \
  && chmod +x /usr/local/bin/tini
 
-#ENTRYPOINT ["/usr/local/bin/tini", "--"]
+ENTRYPOINT ["/usr/local/bin/tini", "--"]
 
-#CMD /usr/local/bin/configureBclToFastq.pl \
-    #--input-dir $RUN_FOLDER/Data/Intensities/BaseCalls/ \
-    #--output-dir $OUTPUT_FOLDER/Unaligned \
-    #--fastq-cluster-count 0 \
-    #--mismatches $MISMATCHES \
-    #--no-eamss \
-    #--with-failed-reads \
- #&& make -j $CPU_NUM -C $OUTPUT_FOLDER/Unaligned/
+CMD /usr/local/bin/bcl2fastq \
+    --runfolder-dir $RUN_FOLDER \
+    --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
+    --fastq-cluster-count 0 \
+    --barcode-mismatches $MISMATCHES \
+    --with-failed-reads
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ENTRYPOINT ["/usr/local/bin/tini", "--"]
 CMD /usr/local/bin/bcl2fastq \
     --runfolder-dir $RUN_FOLDER \
     --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
-    --fastq-cluster-count 0 \
     --barcode-mismatches $MISMATCHES \
     --with-failed-reads
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM centos:7
 
 MAINTAINER Mingda Jin
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN yum update -y \
+ && yum install -y \
         unzip \
- && rm -rf /var/lib/apt/lists/*
+ && yum clean all
 
 RUN curl -OsSL ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/software/bcl2fastq/bcl2fastq2-v2.17.1.14-Linux-x86_64.zip \
  && unzip bcl2fastq2-v2.17.1.14-Linux-x86_64.zip \
@@ -13,10 +14,10 @@ RUN curl -OsSL ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/software/
  && rm -f bcl2fastq2-v2.17.1.14-Linux-x86_64.rpm \
  && rm -f bcl2fastq2-v2.17.1.14-Linux-x86_64.zip
 
-#ENV RUN_FOLDER /mnt/run
-#ENV OUTPUT_FOLDER /mnt/output
-#ENV MISMATCHES 1
-#ENV CPU_NUM 4
+ENV RUN_FOLDER /mnt/run
+ENV OUTPUT_FOLDER /mnt/output
+ENV MISMATCHES 1
+ENV CPU_NUM 4
 
 # install tini - a tiny init process (PID 1) for containers
 # https://github.com/krallin/tini

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN curl -OsSL ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/software/
 ENV RUN_FOLDER /mnt/run
 ENV OUTPUT_FOLDER /mnt/output
 ENV MISMATCHES 1
-#ENV CPU_NUM 4
 
 # install tini - a tiny init process (PID 1) for containers
 # https://github.com/krallin/tini

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Replace `<run folder>` and `<output folder>` with the real directory names on ho
 
 ```bash
 /usr/local/bin/bcl2fastq \
-    --runfolder-dir $RUN_FOLDER \
-    --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
-    --barcode-mismatches $MISMATCHES \
+    --runfolder-dir /mnt/run \
+    --output-dir /mnt/output/Data/Intensities/BaseCalls \
+    --barcode-mismatches 1 \
     --with-failed-reads
 ```
 
@@ -31,7 +31,7 @@ Replace `<run folder>` and `<output folder>` with the real directory names on ho
 
 You can configure the execution of `bcl2fastq2` with the following Docker options.
 
-* `-e "MISMATCHES=0"` - Comma-delimited list of number of mismatches allowed for each read (for example: 1,1). If a single value is provide, all index reads will allow the same number mismatches.
+* `-e "MISMATCHES=1"` - Comma-delimited list of number of mismatches allowed for each read (for example: 1,1). If a single value is provide, all index reads will allow the same number mismatches.
 
 
 ## Custom Bcl2fastq2 Command
@@ -47,7 +47,8 @@ docker run -d --name bcl2fastq2 \
     /usr/local/bin/bcl2fastq \
         --runfolder-dir $RUN_FOLDER \
         --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
-        --barcode-mismatches $MISMATCHES
+        --barcode-mismatches 2 \
+        --no-lane-splitting
 ```
 
 **Alternatively**, you can first start an interactive bash session.
@@ -66,7 +67,8 @@ And then execute `bcl2fastq` command in the shell. For example:
 /usr/local/bin/bcl2fastq \
     --runfolder-dir $RUN_FOLDER \
     --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
-    --barcode-mismatches 2
+    --barcode-mismatches 2 \
+    --no-lane-splitting
 ```
 
 Use `ctrl-p + ctrl-q` to detach the tty without exiting the shell.
@@ -75,3 +77,5 @@ Use `ctrl-p + ctrl-q` to detach the tty without exiting the shell.
 ## Note
 
 * Run `docker logs <container name>` to fetch the logs of a container. Run `docker logs -f <container name>` to follow container log output real-time.
+
+* Please be aware that the format of SampleSheet used by Bcl2fastq2 is differnt from that of Bcl2fastq.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ You can refer to the official [Bcl2fastq2 User Guide](https://support.illumina.c
 
 ## Quick Start
 
-Make sure `SampleSheet.csv` is located under `<run folder>`, and the user that runs `docker run` command on host machine has read permission to `<run folder>` and read/write permission to `<output folder>`.
+Make sure a valid `SampleSheet.csv` is located under `<run folder>`, and the user that runs `docker run` command on host machine has read permission to `<run folder>` and read/write permission to `<output folder>`.
 
 ```bash
 docker run -d --name bcl2fastq2 \

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ Use `ctrl-p + ctrl-q` to detach the tty without exiting the shell.
 
 * Run `docker logs <container name>` to fetch the logs of a container. Run `docker logs -f <container name>` to follow container log output real-time.
 
-* Please be aware that the format of SampleSheet used by Bcl2fastq2 is differnt from that of Bcl2fastq.
+* Please be aware that the format of Sample Sheet used by Bcl2fastq2 is different from that of Bcl2fastq.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,27 @@
-[![Docker Build Status](https://img.shields.io/docker/build/zymoresearch/bcl2fastq.svg)](https://hub.docker.com/r/zymoresearch/bcl2fastq/) [![Docker Pulls](https://img.shields.io/docker/pulls/zymoresearch/bcl2fastq.svg)](https://hub.docker.com/r/zymoresearch/bcl2fastq/)
+# Dockerized Bcl2fastq-2.17
 
-# Dockerized Bcl2fastq-1.8.4
-
-You can refer to the official [Bcl2fastq User Guide](https://support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/bcl2fastq/bcl2fastq_letterbooklet_15038058brpmi.pdf) for more information.
+You can refer to the official [Bcl2fastq2 User Guide](https://support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/bcl2fastq/bcl2fastq2_guide_15051736_v2.pdf) for more information.
 
 ## Quick Start
 
-Make sure `SampleSheet.csv` is located under `<run folder>/Data/Intensities/BaseCalls/`, and the user that runs `docker run` command on host machine has read permission to `<run folder>` and read/write permission to `<output folder>`.
+Make sure `SampleSheet.csv` is located under `<run folder>`, and the user that runs `docker run` command on host machine has read permission to `<run folder>` and read/write permission to `<output folder>`.
 
 ```bash
-docker run -d --name bcl2fastq \
+docker run -d --name bcl2fastq2 \
     -u $( id -u $USER ):$( id -g $USER ) \
     -v <run folder>:/mnt/run \
     -v <output folder>:/mnt/output \
-    zymoresearch/bcl2fastq
+    zymoresearch/bcl2fastq:2.17
 ```
 
-Replace `<run folder>` and `<output folder>` with the real directory names on host machine. The name of `<run folder>` may look something like `100723_EAS346_0188_FC626BWAAXX`. This will execute the following `bcl2fastq` command in a container.
+Replace `<run folder>` and `<output folder>` with the real directory names on host machine. The name of `<run folder>` may look something like `100723_EAS346_0188_FC626BWAAXX`. This will execute the following `bcl2fastq2` command in a container.
 
 ```bash
-/usr/local/bin/configureBclToFastq.pl \
-    --input-dir /mnt/run/Data/Intensities/BaseCalls/ \
-    --output-dir /mnt/output/Unaligned \
-    --fastq-cluster-count 0 \
-    --mismatches 1 \
-    --no-eamss \
-    --with-failed-reads && \
-make -j 4 -C /mnt/output/Unaligned/
+/usr/local/bin/bcl2fastq \
+    --runfolder-dir $RUN_FOLDER \
+    --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
+    --barcode-mismatches $MISMATCHES \
+    --with-failed-reads
 ```
 
 **It is strongly recommended to include `-u $( id -u $USER ):$( id -g $USER )` in `docker run` command.** This will make container switch to the user with the same UID and GID as the current user on host machine. However, if `id` command is not available on your operating system, UID and GID can also be passed to container statically with `-u` like `-u 1001:1001`. If no user is specified at runtime, programs will run as root in a container, which may cause some security vulnerabilities.
@@ -34,48 +29,44 @@ make -j 4 -C /mnt/output/Unaligned/
 
 ## Docker Options
 
-You can configure the execution of `bcl2fastq` with the following Docker options.
+You can configure the execution of `bcl2fastq2` with the following Docker options.
 
-* `-e "CPU_NUM=4"` - Specify the extent of parallelization, with the options depending on the setup of your computer or computing cluster.
-
-* `-e "MISMATCHES=1"` - Comma-delimited list of number of mismatches allowed for each read (for example: 1,1). If a single value is provide, all index reads will allow the same number mismatches.
+* `-e "MISMATCHES=0"` - Comma-delimited list of number of mismatches allowed for each read (for example: 1,1). If a single value is provide, all index reads will allow the same number mismatches.
 
 
-## Custom Bcl2fastq Command
+## Custom Bcl2fastq2 Command
 
-You can run your own `bcl2fastq` command by specifying arguments to `docker run`. Please note that a complete command  for bcl conversion and demultiplexing should consist of both `configureBclToFastq.pl` and `make`. For example:
+You can run your own `bcl2fastq2` command by specifying arguments to `docker run`. For example:
 
 ```bash
-docker run -d --name bcl2fastq \
+docker run -d --name bcl2fastq2 \
     -u $( id -u $USER ):$( id -g $USER ) \
     -v <run folder>:/mnt/run \
     -v <output folder>:/mnt/output \
-    zymoresearch/bcl2fastq \
-    configureBclToFastq.pl \
-      --input-dir /mnt/run/Data/Intensities/BaseCalls \
-      --output-dir /mnt/output \
-      --no-eamss && \
-    make -j 4 -C /mnt/output
+    zymoresearch/bcl2fastq:2.17 \
+    /usr/local/bin/bcl2fastq \
+        --runfolder-dir $RUN_FOLDER \
+        --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
+        --barcode-mismatches $MISMATCHES
 ```
 
 **Alternatively**, you can first start an interactive bash session.
 
 ```bash
-docker run -it --name bcl2fastq\
+docker run -it --name bcl2fastq2 \
     -u $( id -u $USER ):$( id -g $USER ) \
     -v <run folder>:/mnt/run \
     -v <output folder>:/mnt/output \
-    zymoresearch/bcl2fastq bash
+    zymoresearch/bcl2fastq:2.17 bash
 ```
 
 And then execute `bcl2fastq` command in the shell. For example:
 
 ```bash
-/usr/local/bin/configureBclToFastq.pl \
-    --input-dir /mnt/run/Data/Intensities/BaseCalls \
-    --output-dir /mnt/output \
-    --no-eamss
-make -j 4 -C /mnt/output
+/usr/local/bin/bcl2fastq \
+    --runfolder-dir $RUN_FOLDER \
+    --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
+    --barcode-mismatches 2
 ```
 
 Use `ctrl-p + ctrl-q` to detach the tty without exiting the shell.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ docker run -d --name bcl2fastq2 \
     zymoresearch/bcl2fastq:2.17 \
     /usr/local/bin/bcl2fastq \
         --runfolder-dir $RUN_FOLDER \
-        --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
-        --barcode-mismatches 2 \
-        --no-lane-splitting
+        --output-dir $OUTPUT_FOLDER \
+        --barcode-mismatches 0
 ```
 
 **Alternatively**, you can first start an interactive bash session.
@@ -61,14 +60,13 @@ docker run -it --name bcl2fastq2 \
     zymoresearch/bcl2fastq:2.17 bash
 ```
 
-And then execute `bcl2fastq` command in the shell. For example:
+And then execute `bcl2fastq2` command in the shell. For example:
 
 ```bash
 /usr/local/bin/bcl2fastq \
     --runfolder-dir $RUN_FOLDER \
-    --output-dir $OUTPUT_FOLDER/Data/Intensities/BaseCalls \
-    --barcode-mismatches 2 \
-    --no-lane-splitting
+    --output-dir $OUTPUT_FOLDER \
+    --barcode-mismatches 0
 ```
 
 Use `ctrl-p + ctrl-q` to detach the tty without exiting the shell.


### PR DESCRIPTION
New Docker image for Bcl2fastq v2.17 with updated README file.